### PR TITLE
Fix - When no token is passed it should still run the server

### DIFF
--- a/index.js
+++ b/index.js
@@ -323,7 +323,7 @@ module.exports = class HypercoreBlobServer {
 
     const info = decodeRequest(req)
 
-    if (info === null || info.token !== this.token) {
+    if (this.token !== '' && (info === null || info.token !== this.token)) {
       res.statusCode = 404
       res.end()
       return


### PR DESCRIPTION
- At present, when `token: false` it result is in empty string however that case was not added to the logic when processing the request
- Do let me know if its the correct way?

#13 