### PR TITLE
Support bad range requests by returning 416 w/ correct header

### DIFF
--- a/index.js
+++ b/index.js
@@ -420,6 +420,16 @@ module.exports = class HypercoreBlobServer {
       const end = info.range.end === -1 ? info.blob.byteLength - 1 : Math.min(info.range.end, info.blob.byteLength - 1)
 
       start = info.range.start
+
+      // Invalid range response
+      if (start > length || start > end) {
+        res.statusCode = 416
+        res.setHeader('Content-Range', 'bytes */' + info.blob.byteLength)
+        core.close().catch(noop)
+        res.end()
+        return
+      }
+
       length = end - start + 1
 
       res.statusCode = 206

--- a/test/blobs.js
+++ b/test/blobs.js
@@ -60,6 +60,36 @@ test('can get blob from hypercore - multiple blocks', async function (t) {
   t.is(await res.text(), 'Hello World')
 })
 
+test('request bad range', async function (t) {
+  const store = new Corestore(await tmp())
+
+  const blobs = testHyperblobs(t, store)
+
+  const id = await blobs.put(b4a.from('Hello World'))
+
+  const server = testBlobServer(t, store)
+  await server.listen()
+
+  const link = server.getLink(blobs.core.key, { blob: id })
+
+  {
+    const res = await fetch(link, { headers: { range: 'bytes=129-1210' } })
+    t.is(res.status, 416, 'returns 416')
+    t.is(res.headers.get('content-range'), `bytes */${id.byteLength}`, 'returns content-range w/ "*"/length')
+  }
+
+  {
+    const res = await fetch(link, { headers: { range: 'bytes=1337-123' } })
+    t.is(res.status, 416, 'returns 416 for start > end')
+  }
+
+  {
+    const res = await fetch(link, { headers: { range: 'bytes=0-123' } })
+    t.is(res.status, 206, 'returns 206 for end > length')
+    t.is(res.headers.get('content-range'), `bytes 0-${id.byteLength - 1}/${id.byteLength}`, 'returns content-range')
+  }
+})
+
 test('can get a partial blob from hypercore', async function (t) {
   const store = new Corestore(await tmp())
 


### PR DESCRIPTION
References:

- https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/416 (Returned status code & info about `Content-Range` header)
- https://www.rfc-editor.org/info/rfc9110/#byte.ranges (used this to reference that even if `end` > `length` it should just return the bytes to the full length (aka `length - 1`).