### PR TITLE
Enable more headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -256,7 +256,8 @@ module.exports = class HypercoreBlobServer {
       protocol = 'http',
       anyPort = true,
       resolve = defaultResolve,
-      blobCacheLimit = 64
+      blobCacheLimit = 64,
+      sandbox = true
     } = opts
 
     this.store = store
@@ -266,6 +267,7 @@ module.exports = class HypercoreBlobServer {
     this.token = token ? (typeof token === 'string') ? token : z32.encode(token) : ''
     this.anyPort = anyPort
     this.protocol = protocol
+    this.sandbox = sandbox
     this.server = null
     this.blobCache = new BlobCache(blobCacheLimit)
     this.connections = new Set()
@@ -382,6 +384,7 @@ module.exports = class HypercoreBlobServer {
       type: info.type || getMimeType(info.filename)
     })
 
+    if (this.sandbox) res.setHeader('Content-Security-Policy', 'sandbox')
     res.statusCode = 307
     res.setHeader('Location', path)
     res.end()
@@ -396,6 +399,7 @@ module.exports = class HypercoreBlobServer {
       return
     }
 
+    if (this.sandbox) res.setHeader('Content-Security-Policy', 'sandbox')
     res.setHeader('Content-Type', info.type)
     res.setHeader('Content-Length', '' + buffer.byteLength)
     res.end(buffer)
@@ -410,6 +414,7 @@ module.exports = class HypercoreBlobServer {
       return
     }
 
+    if (this.sandbox) res.setHeader('Content-Security-Policy', 'sandbox')
     res.setHeader('Accept-Ranges', 'bytes')
     res.setHeader('Content-Type', info.type)
 

--- a/test/headers.js
+++ b/test/headers.js
@@ -1,0 +1,48 @@
+const test = require('brittle')
+const b4a = require('b4a')
+const Corestore = require('corestore')
+const { testBlobServer, testHyperblobs, fetch } = require('./helpers')
+
+test('sandbox option sets Content-Security-Policy on blob response', async function (t) {
+  const store = new Corestore(await t.tmp())
+
+  const blobs = testHyperblobs(t, store)
+
+  const id = await blobs.put(b4a.from('Hello World'))
+
+  const server = testBlobServer(t, store, { sandbox: true })
+  await server.listen()
+
+  const link = server.getLink(blobs.core.key, { blob: id })
+  const res = await fetch(link)
+  t.is(res.status, 200)
+  t.is(res.headers.get('content-security-policy'), 'sandbox')
+})
+
+test('sandbox option sets Content-Security-Policy on pointer response', async function (t) {
+  const store = new Corestore(await t.tmp())
+
+  const server = testBlobServer(t, store, { sandbox: true })
+  await server.listen()
+
+  const url = server.getBlobLink(b4a.from('hello world'))
+  const res = await fetch(url)
+  t.is(res.status, 200)
+  t.is(res.headers.get('content-security-policy'), 'sandbox')
+})
+
+test('no Content-Security-Policy header when sandbox disabled', async function (t) {
+  const store = new Corestore(await t.tmp())
+
+  const blobs = testHyperblobs(t, store)
+
+  const id = await blobs.put(b4a.from('Hello World'))
+
+  const server = testBlobServer(t, store, { sandbox: false })
+  await server.listen()
+
+  const link = server.getLink(blobs.core.key, { blob: id })
+  const res = await fetch(link)
+  t.is(res.status, 200)
+  t.is(res.headers.get('content-security-policy'), null)
+})


### PR DESCRIPTION
Adds support for the `Content-Security-Policy` header via a `sandbox` constructor option.